### PR TITLE
chore: textual change to resync policies bot across repos

### DIFF
--- a/policies/cla.yml
+++ b/policies/cla.yml
@@ -1,5 +1,5 @@
 name: Contributor License Agreement Policy 
-description: CLA policy file
+description: CLA policy file configuration
 
 resource: repository
 


### PR DESCRIPTION
This PR performs a simple text change on the policy file to resync changes in policy bot. 

This is an attempt to fix the policy bot not running on the https://github.com/microsoftgraph/kiota-dom-export-diff-tool tool and the github ops team suggested a change to this file. 